### PR TITLE
Small documentation fixes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -911,7 +911,7 @@
                   "$ref": "#/components/schemas/Glossary"
                 },
                 "example": {
-                  "id": "def3a26b-3e84-45b3-84ae-0c0aaf3525f7",
+                  "glossary_id": "def3a26b-3e84-45b3-84ae-0c0aaf3525f7",
                   "name": "My Glossary",
                   "ready": true,
                   "source_lang": "EN",

--- a/openapi.json
+++ b/openapi.json
@@ -8,7 +8,7 @@
       "name": "DeepL - Contact us",
       "url": "https://www.deepl.com/contact-us"
     },
-    "version": "2.7.0"
+    "version": "2.9.0"
   },
   "externalDocs": {
     "description": "DeepL Pro - Plans and pricing",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,7 +7,7 @@ info:
   contact:
     name: DeepL - Contact us
     url: https://www.deepl.com/contact-us
-  version: 2.7.0
+  version: 2.9.0
 externalDocs:
   description: DeepL Pro - Plans and pricing
   url: https://www.deepl.com/pro#developer?cta=header-prices/

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -833,7 +833,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Glossary'
               example:
-                id: def3a26b-3e84-45b3-84ae-0c0aaf3525f7
+                glossary_id: def3a26b-3e84-45b3-84ae-0c0aaf3525f7
                 name: My Glossary
                 ready: true
                 source_lang: EN


### PR DESCRIPTION
This PR fixes two small issues with the OpenAPI documents:

 - The documented API version (`2.7.0`) does not match the latest tag (`v2.9.0`)
 - The `/glossaries/{glossary_id}` response example states `"id"` instead of the returned `"glossary_id"` key