### PR TITLE
Fix example nesting so that examples show properly in GitBook

### DIFF
--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -388,7 +388,7 @@ paths:
                        * `done` - the translation is done and the translated document is ready for download
                        * `error` - an irrecoverable error occurred while translating the document
                     type: string
-                    example: translating
+                    example: done
                     enum:
                     - queued
                     - translating
@@ -399,7 +399,6 @@ paths:
                       Estimated number of seconds until the translation is done.
                       This parameter is only included while `status` is `"translating"`.
                     type: integer
-                    example: 20
                   billed_characters:
                     description: The number of characters billed to your account.
                       The characters will only be billed after a successful download

--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -543,12 +543,12 @@ paths:
                           description: The language in which the source texts in the
                             glossary are specified.
                           type: string
-                          example: en
+                          example: EN
                         target_lang:
                           description: The language in which the target texts in the
                             glossary are specified.
                           type: string
-                          example: de
+                          example: DE
               example:
                 supported_languages:
                 - source_lang: de
@@ -888,7 +888,7 @@ paths:
           - source
           - target
           default: source
-          description: Supported values are "source" or "target". If type parameter is not included, defaults to "source".
+        description: Supported values are "source" or "target". If type parameter is not included, defaults to "source".
         examples:
           target:
             summary: Target Languages
@@ -911,7 +911,7 @@ paths:
                     language:
                       description: The language code of the given language.
                       type: string
-                      example: de
+                      example: DE
                     name:
                       description: Name of the language in English.
                       type: string

--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -543,12 +543,12 @@ paths:
                           description: The language in which the source texts in the
                             glossary are specified.
                           type: string
-                          example: EN
+                          example: en
                         target_lang:
                           description: The language in which the target texts in the
                             glossary are specified.
                           type: string
-                          example: DE
+                          example: de
               example:
                 supported_languages:
                 - source_lang: de

--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -306,12 +306,14 @@ paths:
                       the translation process. Must be used when referring to this
                       particular document in subsequent API requests.
                     type: string
+                    example: 04DE5AD98A02647D83285A36021911C6
                   document_key:
                     description: A unique key that is used to encrypt the uploaded
                       document as well as the resulting translation on the server
                       side. Must be provided with every subsequent API request regarding
                       this particular document.
                     type: string
+                    example: 0CB0054F1C132C1625B392EADDA41CB754A742822F6877173029A6C487E7F60A
               example:
                 document_id: 04DE5AD98A02647D83285A36021911C6
                 document_key: 0CB0054F1C132C1625B392EADDA41CB754A742822F6877173029A6C487E7F60A
@@ -377,6 +379,7 @@ paths:
                       the requested translation process. The same ID that was used
                       when requesting the translation status.
                     type: string
+                    example: 04DE5AD98A02647D83285A36021911C6
                   status:
                     description: |-
                       A short description of the state the document translation process is currently in. Possible values are:
@@ -385,6 +388,7 @@ paths:
                        * `done` - the translation is done and the translated document is ready for download
                        * `error` - an irrecoverable error occurred while translating the document
                     type: string
+                    example: translating
                     enum:
                     - queued
                     - translating
@@ -395,11 +399,13 @@ paths:
                       Estimated number of seconds until the translation is done.
                       This parameter is only included while `status` is `"translating"`.
                     type: integer
+                    example: 20
                   billed_characters:
                     description: The number of characters billed to your account.
                       The characters will only be billed after a successful download
                       request.
                     type: integer
+                    example: 1337
                   error_message:
                     description: |-
                       A short description of the error, if available.
@@ -537,10 +543,12 @@ paths:
                           description: The language in which the source texts in the
                             glossary are specified.
                           type: string
+                          example: en
                         target_lang:
                           description: The language in which the target texts in the
                             glossary are specified.
                           type: string
+                          example: de
               example:
                 supported_languages:
                 - source_lang: de
@@ -903,13 +911,16 @@ paths:
                     language:
                       description: The language code of the given language.
                       type: string
+                      example: de
                     name:
                       description: Name of the language in English.
                       type: string
+                      example: German
                     supports_formality:
                       description: Denotes formality support in case of a target language
                         listing.
                       type: boolean
+                      example: true
               example:
               - language: BG
                 name: Bulgarian

--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -888,7 +888,7 @@ paths:
           - source
           - target
           default: source
-        description: Supported values are "source" or "target". If type parameter is not included, defaults to "source".
+          description: Supported values are "source" or "target". If type parameter is not included, defaults to "source".
         examples:
           target:
             summary: Target Languages

--- a/openapi_gitbook.yaml
+++ b/openapi_gitbook.yaml
@@ -411,6 +411,7 @@ paths:
                       Note that the content is subject to change.
                       This parameter may be included if an error occurred during translation.
                     type: string
+                    example: Only available if document status is error
               examples:
                 translating:
                   summary: Translating


### PR DESCRIPTION
Various examples that had been auto-generated for GitBook OpenAPI blocks were not showing the correct values, and instead were showing placeholders like "text". This PR adds examples to various properties in OpenAPI so that they show up properly in GitBook.