### PR TITLE
fix: default Translate tag_handling_version is v2

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5615,8 +5615,8 @@
         "description": "Sets which version of the tag handling algorithm should be used. Options currently available:\n * `v2`: Improved algorithm released in October 2025 (default as of December 2025).\n * `v1`: Traditional algorithm (default until December 2025).",
         "type": "string",
         "enum": [
-          "v1",
-          "v2"
+          "v2",
+          "v1"
         ]
       },
       "UsageResponse": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4330,8 +4330,8 @@ components:
          * `v1`: Traditional algorithm (default until December 2025).
       type: string
       enum:
-      - v1
       - v2
+      - v1
     UsageResponse:
       type: object
       properties:


### PR DESCRIPTION
Since December 2025, the default tag handling version is v2. In our docs, the first option of the enum is used as the default value, so we update the ordering in the spec to put `v2` first to correctly reflect this.