### PR TITLE
Add DeepL-Auth-Key default in API playground

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3992,7 +3992,8 @@
         "type": "apiKey",
         "description": "Authentication with `Authorization` header and `DeepL-Auth-Key` authentication scheme",
         "name": "Authorization",
-        "in": "header"
+        "in": "header",
+        "x-default": "DeepL-Auth-Key "
       }
     },
     "schemas": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2759,6 +2759,7 @@ components:
         authentication scheme
       name: Authorization
       in: header
+      x-default: "DeepL-Auth-Key "
   schemas:
     ApiKeyId:
       description: API key ID. Consists of two valid GUIDs separated by a colon.


### PR DESCRIPTION
## Summary
- Adds `x-default: "DeepL-Auth-Key "` to the `auth_header` security scheme so the Mintlify API playground pre-fills the Authorization field with the `DeepL-Auth-Key` prefix
- Updated both YAML and JSON files
- Unfortunately there's no way to have it show up as DeepL-Auth-Key <your-key-here> because Mintlify stops parsing at the first space. But this should nudge users in the right direction

## Related
- Companion PR in [DeepLcom/api-docs](https://github.com/DeepLcom/api-docs/pull/284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="764" height="322" alt="image" src="https://github.com/user-attachments/assets/3b4f3b25-63a9-4ff3-aeea-fe2f758d07d5" />